### PR TITLE
provide error message if using an unsupported tensorflow version

### DIFF
--- a/src/PolygonModel.py
+++ b/src/PolygonModel.py
@@ -1,7 +1,7 @@
 import tensorflow as tf
 import numpy as np
 import utils
-
+from distutils.version import LooseVersion
 
 class PolygonModel(object):
     """Class to load PolygonModel and run inference."""
@@ -22,6 +22,15 @@ class PolygonModel(object):
 
     def __init__(self, meta_graph_path, graph=None):
         """Creates and loads PolygonModel. """
+
+        #check whether a supported version of tensorflow is installed
+        if (
+                (LooseVersion(tf.__version__) <  LooseVersion('1.3.0')) 
+             or (LooseVersion(tf.__version__) >= LooseVersion('1.3.1'))
+           ):
+            err_string = 'you are using tensorflow version ' + tf.__version__ + ' but only versions 1.3.0 to 1.3.1 are supported'
+            raise NotImplementedError(err_string)
+
         if graph is None:
             self.graph = tf.Graph()
         else:


### PR DESCRIPTION
demo_inference.sh seems to work with tensorflow versions 1.3.0 to 1.4.2 so I allow anything in that range. I have tested by running demo_inference.sh using tensorflow versions 1.2.0, 1.3.0, 1.4.2, 1.5.0, 1.8.0.